### PR TITLE
Docs: batch-first workflow and Makefile task shortcuts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,48 @@
+.PHONY: help install install-browsers lint typecheck test check-pass check-fail fmt
+
+help:
+	@echo "Available targets:"
+	@echo "  make install           - Install project dependencies via Poetry"
+	@echo "  make install-browsers  - Install Playwright browsers"
+	@echo "  make lint              - Run ruff lint checks"
+	@echo "  make typecheck         - Run mypy"
+	@echo "  make test              - Run pytest"
+	@echo "  make check-pass        - Run pass batch config"
+	@echo "  make check-fail        - Run fail batch config"
+	@echo "  make fmt               - Format code with ruff"
+
+install:
+	poetry install
+
+install-browsers:
+	poetry run playwright install
+
+lint:
+	poetry run ruff check .
+
+typecheck:
+	poetry run mypy src
+
+test:
+	poetry run pytest || ([ $$? -eq 5 ] && echo "No tests collected; treating as pass")
+
+check-pass:
+	poetry run ai-source-citation check-config input/single_search_pass.json \
+	  --csv output/results_pass.csv \
+	  --json output/results_pass.json \
+	  --html output/results_pass.html \
+	  --interactive \
+	  --expand-answer \
+	  --no-headless
+
+check-fail:
+	poetry run ai-source-citation check-config input/single_search_fail.json \
+	  --csv output/results_fail.csv \
+	  --json output/results_fail.json \
+	  --html output/results_fail.html \
+	  --interactive \
+	  --expand-answer \
+	  --no-headless
+
+fmt:
+	poetry run ruff format .

--- a/README.md
+++ b/README.md
@@ -1,340 +1,179 @@
 # AI Source Citation
 
-A Python toolkit for extracting, analysing, and validating sources referenced in AI-generated responses.
+A Python CLI for checking whether Google AI Overview responses:
 
-The project is designed to support AI transparency and citation validation by identifying referenced sources, retrieving their content, and checking whether claims made by AI models are supported by those sources.
+1. cite the expected source domain(s), and
+2. contain an expected answer snippet (optional).
 
-This repository provides reusable utilities for:
+## Batch-first workflow (recommended)
 
-- Extracting citations and references from AI outputs
+The primary workflow is running `check-config` against JSON files in `input/` and writing machine-readable artifacts to `output/`.
 
-- Retrieving referenced web pages
-
-- Analysing source credibility
-
-- Validating whether claims are supported by the cited material
-
-The library is designed to integrate into AI evaluation pipelines, research workflows, and automated fact-checking systems.
+- Use `input/single_search_pass.json` for a known-pass check.
+- Use `input/single_search_fail.json` for a known-fail check.
+- Use `input/example_batch_search.json` (or your own config) for larger batches.
 
 ## Requirements
 
-- Python 3.12
-- Poetry 2.x
-- Playwright
-- Google account (required to reliably obtain AI Overviews in search)
+- Python **3.12+** (repo pins `3.12.12` via `.python-version`)
+- Poetry **2.3.2**
+- Playwright browsers
+- Google account (recommended for stable AI Overview visibility)
 
-## Initialisation
+## Setup
 
-This project uses **Python 3.12**, **pyenv** for Python version management, and **Poetry 2.x** for dependency management.
-
-### Install Python using pyenv
-
-If Python 3.12 is not installed:
+### 1) Python via pyenv
 
 ```bash
-pyenv install 3.12
-```
-
-Set the local Python version for the project:
-
-```bash
-pyenv local 3.12
+pyenv install 3.12.12
+pyenv local 3.12.12
 ```
 
 Verify:
 
 ```bash
+pyenv version
 python --version
 ```
 
-Expected output:
-
-```
-Python 3.12.x
-```
-
-### Install Dependencies with Poetry
-
-Install project dependencies:
+### 2) Install dependencies (Poetry 2.3.2)
 
 ```bash
+poetry env use "$(pyenv which python)"
 poetry install
 ```
 
-Poetry will:
-
-* create a virtual environment
-* install all dependencies defined in `pyproject.toml`
-
-Find the environment to activate:
+### 3) Install Playwright browsers
 
 ```bash
-poetry env activate
+poetry run playwright install
 ```
 
-Source in the returned script.
-
-### Verify the CLI Commands
-
-This project exposes a CLI tool via Poetry.
-
-Check the CLI is available:
+### 4) Confirm CLI
 
 ```bash
 poetry run ai-source-citation --help
 ```
 
-You should see the CLI usage instructions.
+## Login guidance (interactive mode)
 
-## Usage Instructions - Single Shot
+For reliable AI Overview extraction, run with `--interactive --no-headless` and sign in to Google when prompted.
 
-### Run the Tool (Interactive)
+Interactive mode pauses with:
 
-Interactive mode runs the tool, opening a browser window and pausing to allow you to **login to your google account** (this is recommended as AI Overiew is more reliably shown when logged in to an account).
+> Press ENTER in the terminal when ready to continue...
 
-Example:
+After sign-in/consent in the opened browser, return to terminal and press Enter.
 
-```bash
-poetry run ai-source-citation check \
-  "what is the population in the uk in 2026?" \
-  --expected ons.org.uk \ 
-  --no-headless \
-  --profile .pw-profile \
-  --interactive
-```
+## CLI flags (currently supported)
 
+### Shared output/browser flags (`check` and `check-config`)
 
-This will:
+- `--csv <path>`: write CSV report
+- `--json <path>`: write JSON report
+- `--html <path>`: write HTML report
+- `--profile <path>`: Playwright user-data directory
+- `--interactive`: pause for manual login
+- `--headless` / `--no-headless`: browser visibility mode
+- `--expand-answer`: click “Show more” before capture
 
-* Load a browser
-* Pause to allow login to Google
-* Run a search
-* Extract sources
-* Analyse citations
-* Output results to the cli
+### Single-shot-only validation flags (`check`)
 
-### Run the Tool (Non-Headless Mode)
+- `--expected <domain>`: expected citation domain(s); repeatable/comma-separated
+- `--expected-answer <text>`: expected answer text snippet
 
-Non-headless mode launches a visible browser so you can observe the automation.  It is better if you have logged into Google using the interactive instructions above first.
+## Input config format (`check-config`)
 
-Example:
-
-```bash
-poetry run ai-source-citation check \
-  "what is the population in the uk in 2026?" \      
-  --expected ons.org.uk \
-  --no-headless \
-  --profile .pw-profile
-```
-
-This is useful for:
-
-* Debugging
-* Inspecting page behaviour
-* Development work.
-
-### Run the Tool (Headless Mode)
-
-Headless mode runs the full analysis without opening a browser window.
-
-Example:
-
-```bash
-poetry run ai-source-citation check \
-  "what is the population in the uk in 2026?" \
-  --expected ons.gov.uk \
-  --headless \
-  --profile .pw-profile
-```
-
-This will:
-
-* Run a search
-* Extract sources
-* Analyse citations
-* Output results to the console.
-
-### Run the Tool (Expected Answer)
-
-You can check for the expected answer by providing an --expected-answer option
-
-Example:
-
-```bash
-poetry run ai-source-citation check \
-  "What is the latest uk unemployment rate percentage?" \
-  --expected ons.gov.uk \
-  --expected-answer "5.2%" \
-  --no-headless \
-  --profile .pw-profile
-```
-
---expected-answer optionally validates that the returned AI answer contains the expected value.
-
-## Usage Instructions - Batch
-
-The following instructions allow a list of search results to be tested for citations.
-
-As with the single shot version, it is best to have used interactive mode to have logged in to a Google Account first.
-
-### Input File
-
-The following is an example file of searches and exected citations.
+`check-config` expects a JSON object with a `search` array:
 
 ```json
 {
   "search": [
     {
-      "question": "What is the latest uk unemployment rate percentage?",
+      "question": "What is the latest UK unemployment rate percentage?",
       "expected_citation": "ons.gov.uk",
       "expected_answer": "5.2%"
-    },
-    {
-      "question": "What is the latest official figure for inflation in the uk?",
-      "expected_citation": "ons.gov.uk"
-    },
-    {
-      "question": "How many alcohol related deaths were there in 2023?",
-      "expected_citation": "ons.gov.uk"
-    },
-    {
-      "question": "when is eastenders shown in the uk",
-      "expected_citation": "bbc.co.uk"
     }
   ]
 }
 ```
 
-expected_answer is optional. When provided, the tool will check whether the AI response contains the expected answer text.
+`expected_answer` is optional.
 
-### Batch Run (no-headless)
+## Usage
 
-Useful for seeing the browser being launched with each test.
+### Batch pass/fail examples (recommended)
+
+Pass scenario:
 
 ```bash
-poetry run ai-source-citation check-config input/example_batch_search.json \
-  --csv output/results.csv \
-  --json output/results.json \
-  --html output/results.html \
-  --profile .pw-profile \
+poetry run ai-source-citation check-config input/single_search_pass.json \
+  --csv output/results_pass.csv \
+  --json output/results_pass.json \
+  --html output/results_pass.html \
+  --interactive \
   --expand-answer \
   --no-headless
 ```
 
---csv will output results as CSV
---json will output results as JSON
-
-### Batch Run (headless)
-
-**Not suggested for initial runs** This runs without the browser being launched.
+Fail scenario (expected to fail answer match):
 
 ```bash
-poetry run ai-source-citation check-config input/example_batch_search.json \
-  --csv output/results.csv \
-  --json output/results.json \
+poetry run ai-source-citation check-config input/single_search_fail.json \
+  --csv output/results_fail.csv \
+  --json output/results_fail.json \
+  --html output/results_fail.html \
+  --interactive \
+  --expand-answer \
+  --no-headless
+```
+
+### Single-shot example (modern CLI)
+
+```bash
+poetry run ai-source-citation check \
+  "what is the population in the uk in 2025?" \
+  --expected ons.gov.uk \
+  --expected-answer "69,487,000" \
+  --csv output/single.csv \
+  --json output/single.json \
+  --html output/single.html \
   --profile .pw-profile \
-  --headless
+  --interactive \
+  --expand-answer \
+  --no-headless
 ```
 
---csv will output results as CSV
---json will output results as JSON
+## Artifacts and result interpretation
 
-## Example Output
+Typical outputs:
 
-The output is displayed as a table with the following elements:
+- `output/*.csv`: flat table for spreadsheet use
+- `output/*.json`: structured run summary + per-check details
+- `output/*.html`: human-readable report
 
-**provider** - Which search is analysed (initially only Google is supported)
+Key result fields:
 
-**question** - the question analysed
+- `matched`: expected citation domain found in extracted citation domains
+- `answer_matched`: expected answer snippet found in `answer_text` (`true` / `false` / `null`)
+- `status`: `passed` or `failed`
 
-**expected_sources** - the sources that are expected to be cited, those selected with the --expected flag
+In JSON batch output:
 
-**answer_text** - the scraped response returned by the search
+- `summary.checks_passed` and `summary.checks_failed` provide run-level totals.
+- `failures[]` explains why checks failed (for example, `answer did not match expected`).
 
-**citations** - the citations URLs returned alongside the associated search 
+## Makefile shortcuts
 
-**citation_domains** - the top level domain associated with the citations (e.g ons.gov.uk)
+Common tasks are wrapped in `Makefile`:
 
-**citation_labels** - the labels associated with the citations extracted from the browser (e.g Office for National Statistics)
+- `make install` – install Python dependencies
+- `make install-browsers` – install Playwright browsers
+- `make lint` – run Ruff lint checks
+- `make typecheck` – run mypy strict checks
+- `make test` – run pytest
+- `make check-pass` – run `input/single_search_pass.json` batch to `output/results_pass.*`
+- `make check-fail` – run `input/single_search_fail.json` batch to `output/results_fail.*`
+- `make fmt` – run Ruff formatter
 
-**matched** - was AI Overview found and was the expected citation returned. (True or False)
-
-**matched_sources** - the expected sources that matched in the citations
-
-**expected_answer** – optional expected value to check in the AI answer
-
-**answer_matched** – whether the AI answer text contains the expected answer (True / False / null)
-
-### Single shot at the CLI
-
-This will return a tabular output
-
-### Batch mode at the CLI
-
-If the --csv flag is used a CSV file will be written containing the results.
-
-#### CSV Output Headings
-```bash
-provider,question,expected_sources,expected_answer,answer_text,answer_matched,citations,citation_domains,citation_labels,matched,matched_sources
-```
-
-If the --json flag is used a JSON file will be written containing the results.
-
-#### Example JSON Output
-
-```json
-[
-  {
-    "provider": "google",
-    "question": "What is the latest uk unemployment rate percentage?",
-    "expected_sources": "ons.gov.uk",
-    "expected_answer": "5.2%",
-    "answer_text": "The UK unemployment rate for October to December 2025 was 5.2%. This rate, representing 1.88 million people aged 16 and over, is the highest level since 2021. Data released in February 2026 shows an increase in unemployment of 331,000 compared to the previous year. The House of Commons Library +2",
-    "answer_matched": true,
-    "citations": "...https://www.ons.gov.uk&quot;\nhttps://www.ons.gov.uk/employmentandlabourmarket/peoplenotinwork/unemployment#:~:text\\u003dUnemployment%20rate%20(aged%2016%20and\nhttps://encrypted-tbn0.gstatic.com/images?q\\u003dtbn:ANd9GcQWWGtZDUF7R3LsMGLoUAa8xvrreJxS516IFj0FqTXNdLwOpmb6&quot;\nhttps://www.ons.gov.uk/employmentandlabourmarket/peoplenotinwork/unemployment&quot;\n...",
-    "citation_domains": "..ons.gov.uk&quot;, ons.gov.uk, ...",
-    "citation_labels": "The House of Commons Library",
-    "matched": true,
-    "matched_sources": "ons.gov.uk"
-  },
-  {
-    "provider": "google",
-    "question": "What is the latest official figure for inflation in the uk?",
-    "expected_sources": "ons.gov.uk",
-    "answer_text": "The UK annual inflation rate, measured by the Consumer Prices Index (CPI), was 3.0% in January 2026, according to the Office for National Statistics. This is a decrease from 3.4% in December 2025, driven by lower prices for transport and food. The Office for National Statistics (CPIH) (including owner occupiers' housing costs) was 3.2% in January 2026. Office for National Statistics +2",
-    "citations": "https://encrypted-tbn0.gstatic.com/faviconV2?url\\u003dhttps://www.ons.gov.uk\\u0026client\\u003dAIM\\u0026size\\u003d128\\u0026type\\u003dFAVICON\\u0026fallback_opts\\u003dTYPE\nhttps://www.ons.gov.uk&quot;\nhttps://www.ons.gov.uk/economy/inflationandpriceindices#:~:text\\u003dCPIH%20ANNUAL%20RATE%2000:%20ALL\nhttps://encrypted-tbn0.gstatic.com/images?q\\u003dtbn:ANd9GcQWWGtZDUF7R3LsMGLoUAa8xvrreJxS516IFj0FqTXNdLwOpmb6&quot;\nhttps://www.ons.gov.uk/economy/inflationandpriceindices&quot;\nhttps://www.google.com&quot;\nhttps://encrypted-tbn1.gstatic.com/faviconV2?url\\u003dhttps://commonslibrary.parliament.uk\\u0026client\\u003dAIM\\u0026size\\u003d128\\u0026type\\u003dFAVICON\\u0026fallback_opts\\u003dTYPE\nhttps://commonslibrary.parliament.uk&quot;\nhttps://commonslibrary.parliament.uk/research-briefings/sn02792/#:~:text\\u003dLatest%20inflation%20data\nhttps://encrypted-tbn0.gstatic.com/images?q\\u003dtbn:ANd9GcSBdCwc-0eNjUUsUdj9sjx_6DVOYzQ5BpPEBtkQt5YBWJKPo8tv&quot;\nhttps://commonslibrary.parliament.uk/research-briefings/sn02792/&quot;\nhttps://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/december2025#:~:text\\u003dImage%20.csv%20.xls-\nhttps://encrypted-tbn0.gstatic.com/images?q\\u003dtbn:ANd9GcQW6LTfbhxMK32_YtY1th1ofF_gKICmdboxe8KLOM2c5X_BgKnr&quot;\nhttps://www.ons.gov.uk/economy/inflationandpriceindices/bulletins/consumerpriceinflation/december2025&quot;",
-    "citation_domains": "encrypted-tbn0.gstatic.com, ons.gov.uk&quot;, ons.gov.uk, encrypted-tbn0.gstatic.com, ons.gov.uk, google.com&quot;, encrypted-tbn1.gstatic.com, commonslibrary.parliament.uk&quot;, commonslibrary.parliament.uk, encrypted-tbn0.gstatic.com, commonslibrary.parliament.uk, ons.gov.uk, encrypted-tbn0.gstatic.com, ons.gov.uk",
-    "citation_labels": "Office for National Statistics",
-    "matched": true,
-    "matched_sources": "ons.gov.uk"
-  },
-  {
-    "provider": "google",
-    "question": "How many alcohol related deaths were there in 2023?",
-    "expected_sources": "ons.gov.uk",
-    "answer_text": "In 2023, there were 10,473 deaths from alcohol-specific causes registered in the UK, marking the highest number on record and a 4% increase from 2022. The death rate was 15.9 per 100,000 people, with men being twice as likely as women to die from these causes. Office for National Statistics +2",
-    "citations": "https://encrypted-tbn0.gstatic.com/faviconV2?url\\u003dhttps://www.ons.gov.uk\\u0026client\\u003dAIM\\u0026size\\u003d128\\u0026type\\u003dFAVICON\\u0026fallback_opts\\u003dTYPE\nhttps://www.ons.gov.uk&quot;\n...",
-    "citation_domains": "encrypted-tbn0.gstatic.com, ons.gov.uk&quot;, ons.gov.uk, e...",
-    "citation_labels": "Office for National Statistics",
-    "matched": true,
-    "matched_sources": "ons.gov.uk"
-  },
-  {
-    "provider": "google",
-    "question": "when is eastenders shown in the uk",
-    "expected_sources": "bbc.co.uk",
-    "answer_text": "EastEnders typically airs Monday to Thursday at 7:30 pm on BBC One in the UK. Episodes are also available to stream on BBC iPlayer at 6:00 am from Monday to Thursday, allowing viewers to watch early. Schedule changes can occur due to sports or special events. Facebook +6",
-    "citations": "...https://www.bbc.co.uk/programmes/b006m86d/broadcasts/upcoming&quot;",
-    "citation_domains": "... bbc.co.uk&quot;, bbc.co.uk, encrypted-tbn1.gstatic.com, bbc.co.uk",
-    "citation_labels": "Facebook",
-    "matched": true,
-    "matched_sources": "bbc.co.uk"
-  }
-]
-```
-
-## Added Features
-
-By using the **--expand-answer** option the tool will click the "Show More" buttun under Google's AI Overview and capture the full AI response as the answer_text.
-
-By using the **--html output/filename.html** option the tool will generate a simple html report of the results that can be viewed in a browser.
+Use `make help` to list targets.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # AI Source Citation
 
-A Python CLI for checking whether Google AI Overview responses:
+A Python toolkit for extracting, analysing, and validating sources referenced in AI-generated responses.
+While the current CLI focuses on checking Google AI Overview answers, the longer-term goal is to run the same validation pipeline across other AI surfaces.
 
 1. cite the expected source domain(s), and
 2. contain an expected answer snippet (optional).
@@ -73,38 +74,18 @@ After sign-in/consent in the opened browser, return to terminal and press Enter.
 - `--json <path>`: write JSON report
 - `--html <path>`: write HTML report
 - `--profile <path>`: Playwright user-data directory
-- `--interactive`: pause for manual login
-- `--headless` / `--no-headless`: browser visibility mode
-- `--expand-answer`: click “Show more” before capture
+- `--interactive`: pause to manually log in / consent
+- `--headless` / `--no-headless`: toggle visible browser
+- `--expand-answer`: click "Show more" before scraping answer text
 
-### Single-shot-only validation flags (`check`)
+### Single-shot extras (`check`)
 
-- `--expected <domain>`: expected citation domain(s); repeatable/comma-separated
-- `--expected-answer <text>`: expected answer text snippet
+- `--expected <domain>` (repeatable or comma-separated) — required
+- `--expected-answer <text>` (optional snippet match)
 
-## Input config format (`check-config`)
+## Batch mode (recommended)
 
-`check-config` expects a JSON object with a `search` array:
-
-```json
-{
-  "search": [
-    {
-      "question": "What is the latest UK unemployment rate percentage?",
-      "expected_citation": "ons.gov.uk",
-      "expected_answer": "5.2%"
-    }
-  ]
-}
-```
-
-`expected_answer` is optional.
-
-## Usage
-
-### Batch pass/fail examples (recommended)
-
-Pass scenario:
+### Pass example
 
 ```bash
 poetry run ai-source-citation check-config input/single_search_pass.json \
@@ -116,7 +97,9 @@ poetry run ai-source-citation check-config input/single_search_pass.json \
   --no-headless
 ```
 
-Fail scenario (expected to fail answer match):
+Expected outcome: run exits success with passed checks.
+
+### Fail example
 
 ```bash
 poetry run ai-source-citation check-config input/single_search_fail.json \
@@ -128,7 +111,13 @@ poetry run ai-source-citation check-config input/single_search_fail.json \
   --no-headless
 ```
 
-### Single-shot example (modern CLI)
+Expected outcome: run exits non-zero with a failed check (for expected-answer mismatch).
+
+### Interactive/login guidance
+
+With `--interactive --no-headless`, the CLI pauses so you can sign into Google and accept prompts in the browser. After login, return to terminal and press Enter to continue.
+
+## Single-shot mode (quick ad-hoc only)
 
 ```bash
 poetry run ai-source-citation check \
@@ -144,36 +133,27 @@ poetry run ai-source-citation check \
   --no-headless
 ```
 
-## Artifacts and result interpretation
+Use this when you want a one-off check; use batch for repeatable test packs.
 
-Typical outputs:
+## Output artifacts
 
-- `output/*.csv`: flat table for spreadsheet use
-- `output/*.json`: structured run summary + per-check details
+- `output/*.csv`: tabular export for spreadsheets
+- `output/*.json`: structured report (`summary`, `failures`, `results`)
 - `output/*.html`: human-readable report
 
-Key result fields:
+Important fields:
 
-- `matched`: expected citation domain found in extracted citation domains
-- `answer_matched`: expected answer snippet found in `answer_text` (`true` / `false` / `null`)
+- `matched`: expected citation source(s) were found
+- `answer_matched`: expected answer snippet matched
 - `status`: `passed` or `failed`
 
-In JSON batch output:
+## Makefile targets
 
-- `summary.checks_passed` and `summary.checks_failed` provide run-level totals.
-- `failures[]` explains why checks failed (for example, `answer did not match expected`).
-
-## Makefile shortcuts
-
-Common tasks are wrapped in `Makefile`:
-
-- `make install` – install Python dependencies
-- `make install-browsers` – install Playwright browsers
-- `make lint` – run Ruff lint checks
-- `make typecheck` – run mypy strict checks
+- `make install` – install dependencies
+- `make playwright-install` – install Playwright browsers
+- `make lint` – run Ruff checks
+- `make format` – run Ruff formatter
+- `make typecheck` – run mypy
 - `make test` – run pytest
-- `make check-pass` – run `input/single_search_pass.json` batch to `output/results_pass.*`
-- `make check-fail` – run `input/single_search_fail.json` batch to `output/results_fail.*`
-- `make fmt` – run Ruff formatter
-
-Use `make help` to list targets.
+- `make run-pass` – execute batch pass config with CSV/JSON/HTML outputs
+- `make run-fail` – execute batch fail config with CSV/JSON/HTML outputs

--- a/poetry.lock
+++ b/poetry.lock
@@ -507,7 +507,7 @@ version = "2.4.2"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.11"
-groups = ["main"]
+groups = ["main", "dev"]
 files = [
     {file = "numpy-2.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e7e88598032542bd49af7c4747541422884219056c268823ef6e5e89851c8825"},
     {file = "numpy-2.4.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7edc794af8b36ca37ef5fcb5e0d128c7e0595c7b96a2318d1badb6fcd8ee86b1"},
@@ -690,6 +690,22 @@ spss = ["pyreadstat (>=1.2.0)"]
 sql-other = ["SQLAlchemy (>=2.0.0)", "adbc-driver-postgresql (>=0.8.0)", "adbc-driver-sqlite (>=0.8.0)"]
 test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
 xml = ["lxml (>=4.9.2)"]
+
+[[package]]
+name = "pandas-stubs"
+version = "2.3.3.260113"
+description = "Type annotations for pandas"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "pandas_stubs-2.3.3.260113-py3-none-any.whl", hash = "sha256:ec070b5c576e1badf12544ae50385872f0631fc35d99d00dc598c2954ec564d3"},
+    {file = "pandas_stubs-2.3.3.260113.tar.gz", hash = "sha256:076e3724bcaa73de78932b012ec64b3010463d377fa63116f4e6850643d93800"},
+]
+
+[package.dependencies]
+numpy = ">=1.23.5"
+types-pytz = ">=2022.1.1"
 
 [[package]]
 name = "pathspec"
@@ -1087,6 +1103,18 @@ shellingham = ">=1.3.0"
 typing-extensions = ">=3.7.4.3"
 
 [[package]]
+name = "types-pytz"
+version = "2026.1.1.20260408"
+description = "Typing stubs for pytz"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "types_pytz-2026.1.1.20260408-py3-none-any.whl", hash = "sha256:c7e4dec76221fb7d0c97b91ad8561d689bebe39b6bcb7b728387e7ffd8cde788"},
+    {file = "types_pytz-2026.1.1.20260408.tar.gz", hash = "sha256:89b6a34b9198ea2a4b98a9d15cbca987053f52a105fd44f7ce3789cae4349408"},
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 description = "Backported and Experimental Type Hints for Python 3.9+"
@@ -1128,4 +1156,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "b438e566265effeac722ecebae246e381b2f25c9f7966d8e5f8970cc2dc7975f"
+content-hash = "9bcc54b6c67193eeaeaa434b018134800c37b3988837c5994b953939905a1b23"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ rich = "^13.7.1"
 pytest = "^8.3.2"
 ruff = "^0.6.2"
 mypy = "^1.11.1"
+pandas-stubs = "^2.3.2.250926"
 
 [tool.poetry.scripts]
 ai-source-citation = "ai_source_citation.cli:main"

--- a/src/ai_source_citation/cli.py
+++ b/src/ai_source_citation/cli.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+
+import pandas as pd
 from pathlib import Path
-from typing import Any, Iterable, List, Optional, Sequence
+from typing import Any, Iterable, Optional, Sequence
 
 from rich.console import Console
 from rich.table import Table
 
 from ai_source_citation.providers.google import GoogleAiOverviewProvider
+from ai_source_citation.models import CheckResultRow
 from ai_source_citation.reporting import build_json_report, build_row, to_dataframe
 from ai_source_citation.ui.html_report import open_html_report, write_html_report
 
@@ -28,7 +31,7 @@ class SearchRequest:
         self.expected_answer = expected_answer
 
 
-def _parse_expected(values: Iterable[str]) -> List[str]:
+def _parse_expected(values: Iterable[str]) -> list[str]:
     """
     Supports:
       --expected bbc.co.uk
@@ -144,7 +147,7 @@ async def _run_checks_async(
     profile: Optional[str],
     interactive: bool,
     expand_answer: bool,
-) -> list:
+) -> list[CheckResultRow]:
     provider = GoogleAiOverviewProvider(
         headless=headless,
         user_data_dir=profile,
@@ -152,7 +155,7 @@ async def _run_checks_async(
         expand_answer=expand_answer,
     )
 
-    rows: list = []
+    rows: list[CheckResultRow] = []
     for request in requests:
         answer = await provider.fetch(request.question)
 
@@ -167,7 +170,7 @@ async def _run_checks_async(
     return rows
 
 
-def _print_rich_table(df) -> None:
+def _print_rich_table(df: pd.DataFrame) -> None:
     table = Table(title="AI Source Citation")
     for col in df.columns:
         table.add_column(col)
@@ -200,11 +203,11 @@ def _write_outputs(
 ) -> dict[str, Any]:
     import json
 
-    df = to_dataframe(rows)
+    df = to_dataframe(list(rows))
     _print_rich_table(df)
 
     provider = rows[0].provider if rows else "unknown"
-    report_payload = build_json_report(rows, provider=provider)
+    report_payload = build_json_report(list(rows), provider=provider)
 
     if csv_path:
         csv_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/ai_source_citation/models.py
+++ b/src/ai_source_citation/models.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Literal, Optional, Tuple
+from typing import Literal, Optional
 
 ProviderName = Literal["google"]  # extend later
 

--- a/src/ai_source_citation/providers/google.py
+++ b/src/ai_source_citation/providers/google.py
@@ -126,7 +126,7 @@ class GoogleAiOverviewProvider(SearchProvider):
         self._interactive = interactive
         self._expand_answer = expand_answer
 
-    async def _expand_ai_overview_answer(self, page) -> None:
+    async def _expand_ai_overview_answer(self, page: Page) -> None:
         candidates = [
             page.get_by_text("Show more", exact=True),
             page.locator("[role='button']").filter(has_text=re.compile(r"^Show more$")),

--- a/src/ai_source_citation/reporting.py
+++ b/src/ai_source_citation/reporting.py
@@ -38,14 +38,14 @@ def _label_matches_expected(expected: str, label: str) -> bool:
       label: Office for National Statistics
     """
     e = normalize_expected_source(expected)
-    l = label.strip().lower()
+    label_normalized = label.strip().lower()
 
-    if not l:
+    if not label_normalized:
         return False
 
     first_token = e.split(".")[0]
 
-    if first_token and first_token in l:
+    if first_token and first_token in label_normalized:
         return True
 
     aliases: dict[str, set[str]] = {
@@ -57,7 +57,7 @@ def _label_matches_expected(expected: str, label: str) -> bool:
     }
 
     for alias in aliases.get(e, set()):
-        if alias in l:
+        if alias in label_normalized:
             return True
 
     return False

--- a/src/ai_source_citation/ui/html_report.py
+++ b/src/ai_source_citation/ui/html_report.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import html
 import json
 import webbrowser
 from pathlib import Path


### PR DESCRIPTION
## Summary
- Rewrite README around a batch-first workflow using `check-config` inputs in `input/`
- Document current CLI flags for `check` and `check-config`
- Add clear setup guidance for pyenv + Poetry 2.3.2 + Playwright browser install
- Add pass/fail sample commands using `input/single_search_pass.json` and `input/single_search_fail.json`
- Add Makefile targets for install/lint/typecheck/test/check-pass/check-fail/fmt

## Tooling + quality
- Added `pandas-stubs` to dev dependencies to satisfy strict mypy
- Fixed existing lint/type hints in source files so `make lint` and `make typecheck` pass
- `make test` now treats pytest exit code 5 (no tests collected) as non-fatal in this repo

## Validation run
- `make lint` ✅
- `make typecheck` ✅
- `make test` ✅ (no tests collected)
