### PR TITLE
feat: surface citation URLs in HTML report

### DIFF
--- a/src/ai_source_citation/ui/assets/report.css
+++ b/src/ai_source_citation/ui/assets/report.css
@@ -199,6 +199,17 @@ details[open] > .result-summary::before {
   white-space: normal;
 }
 
+.chip a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.chip--matched {
+  background: var(--success-bg);
+  border-color: var(--success-border);
+  font-weight: 600;
+}
+
 .empty-state {
   color: var(--muted);
 }

--- a/src/ai_source_citation/ui/assets/report.js
+++ b/src/ai_source_citation/ui/assets/report.js
@@ -82,26 +82,27 @@
     `;
   }
 
-  function renderCitationLinks(links) {
-    if (!links || links.length === 0) {
-      return '<p class="empty-state">None</p>';
-    }
-
-    return `
-      <ul class="chip-list">
-        ${links
-          .map((item) => {
-            const url = escapeHtml(item.url || "");
-            const classes = item.matched ? "chip chip--matched" : "chip";
-            return `<li class="${classes}"><a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a></li>`;
-          })
-          .join("")}
-      </ul>
-    `;
-  }
 
   function renderCard(result) {
     const statusClass = result.status === "passed" ? "result-card--passed" : "result-card--failed";
+    const citationLinksHtml = (() => {
+      const links = result.citation_links || [];
+      if (!links || !links.length) {
+        return '<p class="empty-state">None</p>';
+      }
+      return `
+        <ul class="chip-list">
+          ${links
+            .map((item) => {
+              const url = escapeHtml(item.url || "");
+              const classes = item.matched ? "chip chip--matched" : "chip";
+              return `<li class="${classes}"><a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a></li>`;
+            })
+            .join("")}
+        </ul>
+      `;
+    })();
+
     const statusLabel = result.status === "passed" ? "PASS" : "FAIL";
     const reasonHtml = result.status === "failed"
       ? `<p><strong>Failure reason:</strong> ${escapeHtml(result.failure_reason || "check failed")}</p>`
@@ -165,7 +166,7 @@
 
           <section class="detail-block">
             <h3>Citation URLs</h3>
-            ${renderCitationLinks(result.citation_links || [])}
+            ${citationLinksHtml}
           </section>
 
           <section class="detail-block">

--- a/src/ai_source_citation/ui/assets/report.js
+++ b/src/ai_source_citation/ui/assets/report.js
@@ -71,6 +71,17 @@
     }  
 
   function renderList(items) {
+    if (!items || items.length === 0) {
+      return '<p class="empty-state">None</p>';
+    }
+
+    return `
+      <ul class="chip-list">
+        ${items.map((item) => `<li class="chip">${escapeHtml(item)}</li>`).join("")}
+      </ul>
+    `;
+  }
+
   function renderCitationLinks(links) {
     if (!links || links.length === 0) {
       return '<p class="empty-state">None</p>';
@@ -85,17 +96,6 @@
             return `<li class="${classes}"><a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a></li>`;
           })
           .join("")}
-      </ul>
-    `;
-  }
-
-    if (!items || items.length === 0) {
-      return '<p class="empty-state">None</p>';
-    }
-
-    return `
-      <ul class="chip-list">
-        ${items.map((item) => `<li class="chip">${escapeHtml(item)}</li>`).join("")}
       </ul>
     `;
   }

--- a/src/ai_source_citation/ui/assets/report.js
+++ b/src/ai_source_citation/ui/assets/report.js
@@ -71,6 +71,24 @@
     }  
 
   function renderList(items) {
+  function renderCitationLinks(links) {
+    if (!links || links.length === 0) {
+      return '<p class="empty-state">None</p>';
+    }
+
+    return `
+      <ul class="chip-list">
+        ${links
+          .map((item) => {
+            const url = escapeHtml(item.url || "");
+            const classes = item.matched ? "chip chip--matched" : "chip";
+            return `<li class="${classes}"><a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a></li>`;
+          })
+          .join("")}
+      </ul>
+    `;
+  }
+
     if (!items || items.length === 0) {
       return '<p class="empty-state">None</p>';
     }
@@ -143,6 +161,11 @@
           <section class="detail-block">
             <h3>Citation domains</h3>
             ${renderList(result.citation_domains || [])}
+          </section>
+
+          <section class="detail-block">
+            <h3>Citation URLs</h3>
+            ${renderCitationLinks(result.citation_links || [])}
           </section>
 
           <section class="detail-block">

--- a/src/ai_source_citation/ui/html_report.py
+++ b/src/ai_source_citation/ui/html_report.py
@@ -62,6 +62,15 @@ def _normalise_results_payload(payload: dict[str, Any]) -> dict[str, Any]:
             if item.get("url_matched") is False and item.get("url")
         ]
         citation_domains = result.get("citation_domains", [])
+        citation_urls = result.get("citations", [])
+        matched_url_set = {url for url in matched_urls if url}
+        citation_links = [
+            {
+                "url": url,
+                "matched": url in matched_url_set,
+            }
+            for url in citation_urls
+        ]
 
         enriched = dict(result)
         enriched["status"] = "passed" if matched and answer_ok else "failed"
@@ -77,6 +86,7 @@ def _normalise_results_payload(payload: dict[str, Any]) -> dict[str, Any]:
         enriched["matched_urls"] = matched_urls
         enriched["missing_urls"] = missing_urls
         enriched["citation_domains"] = citation_domains
+        enriched["citation_links"] = citation_links
         enriched_results.append(enriched)
 
     return {

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,5 +1,6 @@
 from ai_source_citation.models import AiAnswer, Citation, ExpectedCitation
 from ai_source_citation.reporting import build_row, _failure_reason
+from ai_source_citation.ui.html_report import build_html_report
 
 
 def _basic_answer(citations):
@@ -76,3 +77,37 @@ def test_build_row_fails_when_url_missing():
     assert row.matched is False
     assert row.expected_citations[0].url_matched is False
     assert "URLs" in _failure_reason(row)
+
+
+def test_html_report_contains_citation_urls():
+    payload = {
+        "run": {"provider": "google", "timestamp": "2026-04-14T00:00:00Z"},
+        "summary": {"checks_run": 1, "checks_passed": 1, "checks_failed": 0},
+        "results": [
+            {
+                "provider": "google",
+                "question": "sample question",
+                "matched": True,
+                "answer_matched": True,
+                "expected_answer": "demo",
+                "answer_text": "demo",
+                "citations": ["https://example.com/matched", "https://example.com/other"],
+                "citation_domains": ["example.com"],
+                "citation_labels": ["Example"],
+                "expected_citations": [
+                    {
+                        "domain": "example.com",
+                        "url": "https://example.com/matched",
+                        "domain_matched": True,
+                        "url_matched": True,
+                    }
+                ],
+            }
+        ],
+    }
+
+    html = build_html_report(payload)
+
+    assert "https://example.com/matched" in html
+    assert "https://example.com/other" in html
+    assert "chip--matched" in html


### PR DESCRIPTION
## Summary
- show the actual AI Overview citation URLs in the HTML report, wrapping long links to stay within the card
- highlight matched URLs when an expected citation specifies one, reusing the chip styling
- expose the citations to the UI payload and add a regression test to ensure the URLs are present in the generated HTML

## Testing
- poetry run ruff check src tests
- poetry run mypy src
- poetry run pytest