### PR TITLE
Fix URL citation matching when citation contains text fragments

### DIFF
--- a/src/ai_source_citation/matching.py
+++ b/src/ai_source_citation/matching.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from typing import Iterable
+from urllib.parse import urlsplit, urlunsplit
 
 
 @dataclass(frozen=True)
@@ -51,3 +52,13 @@ def find_matches(
             seen.add(x)
             out.append(x)
     return out
+
+
+def normalize_url_for_match(url: str) -> str:
+    """Normalize URL for equality checks while preserving non-fragment parts."""
+    value = url.strip()
+    if not value:
+        return value
+
+    parts = urlsplit(value)
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, parts.query, ""))

--- a/src/ai_source_citation/reporting.py
+++ b/src/ai_source_citation/reporting.py
@@ -12,7 +12,11 @@ from ai_source_citation.models import (
     ExpectedCitation,
     ExpectedCitationResult,
 )
-from ai_source_citation.matching import find_matches, normalize_expected_source
+from ai_source_citation.matching import (
+    find_matches,
+    normalize_expected_source,
+    normalize_url_for_match,
+)
 
 
 def _normalize_text(value: str) -> str:
@@ -178,7 +182,7 @@ def _evaluate_expected_citations(
         for citation in expected_citations
         if any(_label_matches_expected(citation.domain, label) for label in citation_labels)
     }
-    url_set = set(citation_urls)
+    normalized_citation_urls = {normalize_url_for_match(url) for url in citation_urls}
 
     results: list[ExpectedCitationResult] = []
     for expected in expected_citations:
@@ -190,7 +194,8 @@ def _evaluate_expected_citations(
         url_norm = expected.url.strip() if expected.url else None
         url_matched = None
         if url_norm:
-            url_matched = url_norm in url_set
+            expected_url_normalized = normalize_url_for_match(url_norm)
+            url_matched = expected_url_normalized in normalized_citation_urls
 
         results.append(
             ExpectedCitationResult(

--- a/src/ai_source_citation/ui/assets/report.js
+++ b/src/ai_source_citation/ui/assets/report.js
@@ -83,6 +83,23 @@
   }
 
 
+  function renderUrlList(items) {
+    if (!items || items.length === 0) {
+      return '<p class="empty-state">None</p>';
+    }
+
+    return `
+      <ul class="chip-list">
+        ${items
+          .map((item) => {
+            const url = escapeHtml(item);
+            return `<li class="chip"><a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a></li>`;
+          })
+          .join("")}
+      </ul>
+    `;
+  }
+
   function renderCard(result) {
     const statusClass = result.status === "passed" ? "result-card--passed" : "result-card--failed";
     const citationLinksHtml = (() => {
@@ -146,17 +163,17 @@
 
           <section class="detail-block">
             <h3>Expected URLs</h3>
-            ${renderList(result.expected_urls || [])}
+            ${renderUrlList(result.expected_urls || [])}
           </section>
 
           <section class="detail-block">
             <h3>Matched URLs</h3>
-            ${renderList(result.matched_urls || [])}
+            ${renderUrlList(result.matched_urls || [])}
           </section>
 
           <section class="detail-block">
             <h3>Missing URLs</h3>
-            ${renderList(result.missing_urls || [])}
+            ${renderUrlList(result.missing_urls || [])}
           </section>
 
           <section class="detail-block">

--- a/src/ai_source_citation/ui/html_report.py
+++ b/src/ai_source_citation/ui/html_report.py
@@ -6,6 +6,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import quote_plus
 
+from ai_source_citation.matching import normalize_url_for_match
+
 ASSETS_DIR = Path(__file__).parent / "assets"
 
 
@@ -63,11 +65,11 @@ def _normalise_results_payload(payload: dict[str, Any]) -> dict[str, Any]:
         ]
         citation_domains = result.get("citation_domains", [])
         citation_urls = result.get("citations", [])
-        matched_url_set = {url for url in matched_urls if url}
+        matched_url_set = {normalize_url_for_match(url) for url in matched_urls if url}
         citation_links = [
             {
                 "url": url,
-                "matched": url in matched_url_set,
+                "matched": normalize_url_for_match(url) in matched_url_set,
             }
             for url in citation_urls
         ]

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -111,3 +111,81 @@ def test_html_report_contains_citation_urls():
     assert "https://example.com/matched" in html
     assert "https://example.com/other" in html
     assert "chip--matched" in html
+
+
+def test_build_row_url_match_ignores_text_fragment():
+    answer = _basic_answer(
+        [
+            Citation(
+                url=(
+                    "https://www.ons.gov.uk/peoplepopulationandcommunity/populationandmigration/"
+                    "populationestimates/bulletins/provisionalpopulationestimatefortheuk/mid2025"
+                    "#:~:text=The%20provisional%20mid%2Dyear%20estimate"
+                ),
+                domain="ons.gov.uk",
+            )
+        ]
+    )
+
+    row = build_row(
+        answer,
+        [
+            ExpectedCitation(
+                domain="ons.gov.uk",
+                url=(
+                    "https://www.ons.gov.uk/peoplepopulationandcommunity/populationandmigration/"
+                    "populationestimates/bulletins/provisionalpopulationestimatefortheuk/mid2025"
+                ),
+            )
+        ],
+    )
+
+    assert row.matched is True
+    assert row.expected_citations[0].url_matched is True
+
+
+def test_html_report_expected_and_missing_urls_are_links():
+    payload = {
+        "run": {"provider": "google", "timestamp": "2026-04-15T00:00:00Z"},
+        "summary": {"checks_run": 1, "checks_passed": 0, "checks_failed": 1},
+        "failures": [{"question": "sample", "reason": "URLs did not match expected"}],
+        "results": [
+            {
+                "provider": "google",
+                "question": "sample",
+                "matched": False,
+                "answer_matched": True,
+                "expected_answer": "demo",
+                "answer_text": "demo",
+                "citations": [
+                    "https://example.com/path#:~:text=fragment",
+                    "https://example.com/other",
+                ],
+                "citation_domains": ["example.com"],
+                "citation_labels": ["Example"],
+                "expected_citations": [
+                    {
+                        "domain": "example.com",
+                        "url": "https://example.com/path",
+                        "domain_matched": True,
+                        "url_matched": True,
+                    },
+                    {
+                        "domain": "example.com",
+                        "url": "https://example.com/missing",
+                        "domain_matched": True,
+                        "url_matched": False,
+                    },
+                ],
+            }
+        ],
+    }
+
+    html = build_html_report(payload)
+
+    assert '"expected_urls": ["https://example.com/path", "https://example.com/missing"]' in html
+    assert '"missing_urls": ["https://example.com/missing"]' in html
+    assert '"url": "https://example.com/path#:~:text=fragment", "matched": true' in html
+    assert "renderUrlList(result.expected_urls || [])" in html
+    assert "renderUrlList(result.missing_urls || [])" in html
+    assert "chip--matched" in html


### PR DESCRIPTION
## Summary
Fixes URL matching for expected citations when citation URLs include text fragment identifiers (`#:~:text=...`).

### What changed
- Added URL normalization helper that strips fragment identifiers for match checks.
- Updated expected URL matching to compare normalized URLs while preserving original citation URLs in output.
- Updated HTML payload normalization so citation URL highlighting also uses normalized matching.
- Updated report UI so **Expected URLs**, **Matched URLs**, and **Missing URLs** render as active links (new tab).
- Added/updated tests for fragment-insensitive URL matching and HTML report URL sections.

## Why
Issue #7 reports false negatives when expected URL has no fragment but Google citation includes `#:~:text=...`. Those should be treated as matches.

## Validation
- `poetry run ruff check .`
- `poetry run mypy src`
- `poetry run pytest`

All pass.

Closes #7.
