### PR TITLE
Add citation URL health validation to extraction and reports

### DIFF
--- a/src/ai_source_citation/citation_health.py
+++ b/src/ai_source_citation/citation_health.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import asyncio
+import socket
+import time
+from dataclasses import dataclass
+from typing import Callable
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+@dataclass(frozen=True)
+class CitationHealthResult:
+    url: str
+    final_url: str | None
+    status_code: int | None
+    is_ok: bool
+    is_redirect: bool
+    is_blocked: bool
+    error: str | None
+    response_time_ms: int | None
+
+
+def _classify_status(
+    url: str, status_code: int | None, final_url: str | None
+) -> CitationHealthResult:
+    is_redirect = status_code is not None and 300 <= status_code <= 399
+    is_ok = status_code is not None and (200 <= status_code <= 299 or 300 <= status_code <= 399)
+    is_blocked = status_code == 403
+
+    error: str | None = None
+    if status_code == 403:
+        error = "403 Forbidden"
+    elif status_code == 404:
+        error = "404 Not Found"
+    elif status_code is not None and 500 <= status_code <= 599:
+        error = f"{status_code} Server Error"
+    elif status_code is not None and 400 <= status_code <= 499 and status_code != 403:
+        error = f"{status_code} Client Error"
+
+    return CitationHealthResult(
+        url=url,
+        final_url=final_url,
+        status_code=status_code,
+        is_ok=is_ok,
+        is_redirect=is_redirect,
+        is_blocked=is_blocked,
+        error=error,
+        response_time_ms=None,
+    )
+
+
+class CitationHealthChecker:
+    def __init__(
+        self,
+        *,
+        timeout_seconds: float = 4.0,
+        max_concurrency: int = 8,
+        fetcher: Callable[[str, float], tuple[int | None, str | None]] | None = None,
+    ) -> None:
+        self._timeout_seconds = timeout_seconds
+        self._sem = asyncio.Semaphore(max_concurrency)
+        self._cache: dict[str, CitationHealthResult] = {}
+        self._fetcher = fetcher or self._fetch_sync
+
+    def _fetch_sync(self, url: str, timeout_seconds: float) -> tuple[int | None, str | None]:
+        req = Request(
+            url,
+            headers={
+                "User-Agent": (
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/124.0.0.0 Safari/537.36"
+                )
+            },
+        )
+        with urlopen(req, timeout=timeout_seconds) as response:  # noqa: S310
+            status = response.getcode()
+            final_url = response.geturl()
+            return status, final_url
+
+    async def check(self, url: str) -> CitationHealthResult:
+        cached = self._cache.get(url)
+        if cached is not None:
+            return cached
+
+        async with self._sem:
+            # double-check after waiting on semaphore
+            cached = self._cache.get(url)
+            if cached is not None:
+                return cached
+
+            start = time.perf_counter()
+            try:
+                status_code, final_url = await asyncio.to_thread(
+                    self._fetcher,
+                    url,
+                    self._timeout_seconds,
+                )
+                result = _classify_status(url, status_code, final_url)
+            except HTTPError as exc:
+                result = _classify_status(
+                    url, exc.code, exc.geturl() if hasattr(exc, "geturl") else None
+                )
+            except (TimeoutError, socket.timeout):
+                result = CitationHealthResult(
+                    url=url,
+                    final_url=None,
+                    status_code=None,
+                    is_ok=False,
+                    is_redirect=False,
+                    is_blocked=False,
+                    error="timeout",
+                    response_time_ms=None,
+                )
+            except URLError as exc:
+                result = CitationHealthResult(
+                    url=url,
+                    final_url=None,
+                    status_code=None,
+                    is_ok=False,
+                    is_redirect=False,
+                    is_blocked=False,
+                    error=str(exc.reason),
+                    response_time_ms=None,
+                )
+            except Exception as exc:  # noqa: BLE001
+                result = CitationHealthResult(
+                    url=url,
+                    final_url=None,
+                    status_code=None,
+                    is_ok=False,
+                    is_redirect=False,
+                    is_blocked=False,
+                    error=str(exc),
+                    response_time_ms=None,
+                )
+
+            elapsed_ms = int((time.perf_counter() - start) * 1000)
+            result = CitationHealthResult(
+                url=result.url,
+                final_url=result.final_url,
+                status_code=result.status_code,
+                is_ok=result.is_ok,
+                is_redirect=result.is_redirect,
+                is_blocked=result.is_blocked,
+                error=result.error,
+                response_time_ms=elapsed_ms,
+            )
+            self._cache[url] = result
+            return result
+
+    async def check_many(
+        self, urls: list[str] | tuple[str, ...]
+    ) -> dict[str, CitationHealthResult]:
+        unique_urls: list[str] = []
+        seen: set[str] = set()
+        for url in urls:
+            if url not in seen:
+                seen.add(url)
+                unique_urls.append(url)
+
+        results = await asyncio.gather(*(self.check(url) for url in unique_urls))
+        return {item.url: item for item in results}

--- a/src/ai_source_citation/cli.py
+++ b/src/ai_source_citation/cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+from dataclasses import replace
 from pathlib import Path
 from typing import Any, Iterable, Optional, Sequence
 
@@ -9,7 +10,8 @@ import pandas as pd
 from rich.console import Console
 from rich.table import Table
 
-from ai_source_citation.models import CheckResultRow, ExpectedCitation
+from ai_source_citation.citation_health import CitationHealthChecker
+from ai_source_citation.models import CheckResultRow, Citation, ExpectedCitation
 from ai_source_citation.providers.google import GoogleAiOverviewProvider
 from ai_source_citation.reporting import build_json_report, build_row, to_dataframe
 from ai_source_citation.ui.html_report import open_html_report, write_html_report
@@ -167,10 +169,26 @@ async def _run_checks_async(
         interactive=interactive,
         expand_answer=expand_answer,
     )
+    health_checker = CitationHealthChecker()
 
     rows: list[CheckResultRow] = []
     for request in requests:
         answer = await provider.fetch(request.question)
+
+        health_by_url = await health_checker.check_many(
+            [citation.url for citation in answer.citations]
+        )
+        answer = replace(
+            answer,
+            citations=tuple(
+                Citation(
+                    url=citation.url,
+                    domain=citation.domain,
+                    health=health_by_url.get(citation.url),
+                )
+                for citation in answer.citations
+            ),
+        )
 
         row = build_row(
             answer,
@@ -202,6 +220,11 @@ def _print_run_summary(summary: dict[str, int]) -> None:
     summary_table.add_row("Number of checks run", str(summary["checks_run"]))
     summary_table.add_row("Number of checks passed", str(summary["checks_passed"]))
     summary_table.add_row("Number of checks failed", str(summary["checks_failed"]))
+    if "total_citations_checked" in summary:
+        summary_table.add_row("Total citations checked", str(summary["total_citations_checked"]))
+        summary_table.add_row("Healthy citations", str(summary["healthy_citations"]))
+        summary_table.add_row("Blocked citations", str(summary["blocked_citations"]))
+        summary_table.add_row("Failed citations", str(summary["failed_citations"]))
 
     console.print(summary_table)
 
@@ -216,12 +239,6 @@ def _write_outputs(
 ) -> dict[str, Any]:
     import json
 
-    row_list = list(rows)
-    df = to_dataframe(row_list)
-    _print_rich_table(df)
-
-    provider = row_list[0].provider if row_list else "unknown"
-    report_payload = build_json_report(row_list, provider=provider)
     row_list = list(rows)
     df = to_dataframe(row_list)
     _print_rich_table(df)

--- a/src/ai_source_citation/models.py
+++ b/src/ai_source_citation/models.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Literal, Optional
 
+from ai_source_citation.citation_health import CitationHealthResult
+
 ProviderName = Literal["google"]  # extend later
 
 
@@ -10,6 +12,7 @@ ProviderName = Literal["google"]  # extend later
 class Citation:
     url: str
     domain: str
+    health: CitationHealthResult | None = None
 
 
 @dataclass(frozen=True)
@@ -49,4 +52,5 @@ class CheckResultRow:
     citations: tuple[str, ...]
     citation_domains: tuple[str, ...]
     citation_labels: tuple[str, ...]
+    citation_health: tuple[CitationHealthResult | None, ...]
     matched: bool

--- a/src/ai_source_citation/reporting.py
+++ b/src/ai_source_citation/reporting.py
@@ -94,6 +94,21 @@ def _failure_reason(row: CheckResultRow) -> str:
     return ""
 
 
+def _build_citation_health_summary(rows: Sequence[CheckResultRow]) -> dict[str, int]:
+    all_health = [item for row in rows for item in row.citation_health if item is not None]
+    total = len(all_health)
+    healthy = sum(1 for item in all_health if item.is_ok)
+    blocked = sum(1 for item in all_health if item.is_blocked)
+    failed = total - healthy - blocked
+
+    return {
+        "total_citations_checked": total,
+        "healthy_citations": healthy,
+        "blocked_citations": blocked,
+        "failed_citations": failed,
+    }
+
+
 def _build_run_summary(rows: Sequence[CheckResultRow]) -> dict[str, int]:
     checks_run = len(rows)
     checks_passed = sum(1 for row in rows if _result_status(row) == "passed")
@@ -103,6 +118,7 @@ def _build_run_summary(rows: Sequence[CheckResultRow]) -> dict[str, int]:
         "checks_run": checks_run,
         "checks_passed": checks_passed,
         "checks_failed": checks_failed,
+        **_build_citation_health_summary(rows),
     }
 
 
@@ -125,6 +141,23 @@ def _row_to_json_record(row: CheckResultRow) -> dict[str, Any]:
         "citations": list(row.citations),
         "citation_domains": list(row.citation_domains),
         "citation_labels": list(row.citation_labels),
+        "citation_health": [
+            (
+                {
+                    "url": item.url,
+                    "final_url": item.final_url,
+                    "status_code": item.status_code,
+                    "is_ok": item.is_ok,
+                    "is_redirect": item.is_redirect,
+                    "is_blocked": item.is_blocked,
+                    "error": item.error,
+                    "response_time_ms": item.response_time_ms,
+                }
+                if item is not None
+                else None
+            )
+            for item in row.citation_health
+        ],
         "matched": row.matched,
         "status": _result_status(row),
     }
@@ -217,6 +250,7 @@ def build_row(
     citation_urls = tuple(c.url for c in answer.citations)
     citation_domains = tuple(c.domain for c in answer.citations)
     citation_labels = tuple(answer.citation_labels)
+    citation_health = tuple(c.health for c in answer.citations)
 
     answer_matched = _answer_matches(answer.answer_text, expected_answer)
 
@@ -243,6 +277,7 @@ def build_row(
             citations=tuple(),
             citation_domains=tuple(),
             citation_labels=tuple(),
+            citation_health=tuple(),
             matched=False,
         )
 
@@ -256,6 +291,7 @@ def build_row(
         citations=citation_urls,
         citation_domains=citation_domains,
         citation_labels=citation_labels,
+        citation_health=citation_health,
         matched=matched,
     )
 
@@ -268,6 +304,14 @@ def to_dataframe(rows: list[CheckResultRow]) -> pd.DataFrame:
         matched_domains = [item.domain for item in row.expected_citations if item.domain_matched]
         matched_urls = [item.url for item in row.expected_citations if item.url_matched]
         missing_urls = [item.url for item in row.expected_citations if item.url_matched is False]
+        health_items = [item for item in row.citation_health if item is not None]
+        health_ok = sum(1 for item in health_items if item.is_ok)
+        health_blocked = sum(1 for item in health_items if item.is_blocked)
+        health_failed = len(health_items) - health_ok - health_blocked
+        health_statuses = [
+            f"{item.url} -> {item.status_code if item.status_code is not None else 'ERR'}"
+            for item in health_items
+        ]
 
         frame_rows.append(
             {
@@ -285,6 +329,11 @@ def to_dataframe(rows: list[CheckResultRow]) -> pd.DataFrame:
                 "matched_domains": ", ".join(matched_domains),
                 "matched_urls": ", ".join(filter(None, matched_urls)),
                 "missing_urls": ", ".join(filter(None, missing_urls)),
+                "citations_checked": len(health_items),
+                "citations_healthy": health_ok,
+                "citations_blocked": health_blocked,
+                "citations_failed": health_failed,
+                "citation_health": "\n".join(health_statuses),
             }
         )
 

--- a/src/ai_source_citation/ui/assets/report.css
+++ b/src/ai_source_citation/ui/assets/report.css
@@ -213,3 +213,20 @@ details[open] > .result-summary::before {
 .empty-state {
   color: var(--muted);
 }
+
+.chip--health-ok {
+  border-color: var(--success-border);
+}
+
+.chip--health-blocked {
+  border-color: #e0b15d;
+}
+
+.chip--health-failed {
+  border-color: var(--failure-border);
+}
+
+.chip-health {
+  font-size: 0.8rem;
+  opacity: 0.85;
+}

--- a/src/ai_source_citation/ui/assets/report.js
+++ b/src/ai_source_citation/ui/assets/report.js
@@ -112,8 +112,14 @@
           ${links
             .map((item) => {
               const url = escapeHtml(item.url || "");
-              const classes = item.matched ? "chip chip--matched" : "chip";
-              return `<li class="${classes}"><a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a></li>`;
+              const healthLabel = item.status_code !== null && item.status_code !== undefined
+                ? String(item.status_code)
+                : (item.error ? `ERR: ${escapeHtml(item.error)}` : "ERR");
+              const healthClass = item.is_ok
+                ? "chip--health-ok"
+                : (item.is_blocked ? "chip--health-blocked" : "chip--health-failed");
+              const classes = `${item.matched ? "chip chip--matched" : "chip"} ${healthClass}`;
+              return `<li class="${classes}"><a href="${url}" target="_blank" rel="noopener noreferrer">${url}</a> <span class="chip-health">(${healthLabel})</span></li>`;
             })
             .join("")}
         </ul>
@@ -242,6 +248,22 @@
           <div class="metric">
             <div class="metric-label">Failures</div>
             <div class="metric-value">${escapeHtml(summary.checks_failed ?? 0)}</div>
+          </div>
+          <div class="metric">
+            <div class="metric-label">Citations checked</div>
+            <div class="metric-value">${escapeHtml(summary.total_citations_checked ?? 0)}</div>
+          </div>
+          <div class="metric">
+            <div class="metric-label">Healthy citations</div>
+            <div class="metric-value">${escapeHtml(summary.healthy_citations ?? 0)}</div>
+          </div>
+          <div class="metric">
+            <div class="metric-label">Blocked citations</div>
+            <div class="metric-value">${escapeHtml(summary.blocked_citations ?? 0)}</div>
+          </div>
+          <div class="metric">
+            <div class="metric-label">Failed citations</div>
+            <div class="metric-value">${escapeHtml(summary.failed_citations ?? 0)}</div>
           </div>
         </div>
       </header>

--- a/src/ai_source_citation/ui/html_report.py
+++ b/src/ai_source_citation/ui/html_report.py
@@ -65,11 +65,21 @@ def _normalise_results_payload(payload: dict[str, Any]) -> dict[str, Any]:
         ]
         citation_domains = result.get("citation_domains", [])
         citation_urls = result.get("citations", [])
+        citation_health = result.get("citation_health", [])
+        health_by_url = {
+            item.get("url"): item
+            for item in citation_health
+            if isinstance(item, dict) and item.get("url")
+        }
         matched_url_set = {normalize_url_for_match(url) for url in matched_urls if url}
         citation_links = [
             {
                 "url": url,
                 "matched": normalize_url_for_match(url) in matched_url_set,
+                "status_code": health_by_url.get(url, {}).get("status_code"),
+                "is_ok": health_by_url.get(url, {}).get("is_ok", False),
+                "is_blocked": health_by_url.get(url, {}).get("is_blocked", False),
+                "error": health_by_url.get(url, {}).get("error"),
             }
             for url in citation_urls
         ]

--- a/tests/test_citation_health.py
+++ b/tests/test_citation_health.py
@@ -1,4 +1,6 @@
 import asyncio
+import socket
+from urllib.error import URLError
 
 from ai_source_citation.citation_health import CitationHealthChecker
 
@@ -16,13 +18,73 @@ def test_health_checker_status_classification() -> None:
     assert result.final_url == "https://example.com/final"
 
 
+def test_health_checker_redirect_status_is_pass() -> None:
+    checker = CitationHealthChecker(
+        fetcher=lambda _url, _timeout: (302, "https://example.com/redirected")
+    )
+    result = asyncio.run(checker.check("https://example.com"))
+
+    assert result.is_ok is True
+    assert result.is_redirect is True
+    assert result.is_blocked is False
+    assert result.status_code == 302
+    assert result.final_url == "https://example.com/redirected"
+
+
 def test_health_checker_blocked_status() -> None:
     checker = CitationHealthChecker(fetcher=lambda _url, _timeout: (403, "https://example.com"))
     result = asyncio.run(checker.check("https://example.com"))
 
     assert result.is_ok is False
     assert result.is_blocked is True
+    assert result.status_code == 403
     assert result.error == "403 Forbidden"
+
+
+def test_health_checker_not_found_status_is_failure() -> None:
+    checker = CitationHealthChecker(fetcher=lambda _url, _timeout: (404, "https://example.com"))
+    result = asyncio.run(checker.check("https://example.com/missing"))
+
+    assert result.is_ok is False
+    assert result.is_blocked is False
+    assert result.status_code == 404
+    assert result.error == "404 Not Found"
+
+
+def test_health_checker_server_error_status_is_failure() -> None:
+    checker = CitationHealthChecker(fetcher=lambda _url, _timeout: (503, "https://example.com"))
+    result = asyncio.run(checker.check("https://example.com/down"))
+
+    assert result.is_ok is False
+    assert result.is_blocked is False
+    assert result.status_code == 503
+    assert result.error == "503 Server Error"
+
+
+def test_health_checker_timeout_error() -> None:
+    def fetcher(_url: str, _timeout: float) -> tuple[int | None, str | None]:
+        raise socket.timeout("timed out")
+
+    checker = CitationHealthChecker(fetcher=fetcher)
+    result = asyncio.run(checker.check("https://example.com/slow"))
+
+    assert result.is_ok is False
+    assert result.is_blocked is False
+    assert result.status_code is None
+    assert result.error == "timeout"
+
+
+def test_health_checker_network_error() -> None:
+    def fetcher(_url: str, _timeout: float) -> tuple[int | None, str | None]:
+        raise URLError("dns failure")
+
+    checker = CitationHealthChecker(fetcher=fetcher)
+    result = asyncio.run(checker.check("https://example.com/dns"))
+
+    assert result.is_ok is False
+    assert result.is_blocked is False
+    assert result.status_code is None
+    assert "dns failure" in (result.error or "")
 
 
 def test_health_checker_cache_reuses_result() -> None:
@@ -38,3 +100,25 @@ def test_health_checker_cache_reuses_result() -> None:
 
     assert calls["count"] == 1
     assert result1 == result2
+
+
+def test_health_checker_check_many_deduplicates_urls() -> None:
+    calls = {"count": 0}
+
+    def fetcher(_url: str, _timeout: float) -> tuple[int | None, str | None]:
+        calls["count"] += 1
+        return 200, "https://example.com"
+
+    checker = CitationHealthChecker(fetcher=fetcher)
+    result = asyncio.run(
+        checker.check_many(
+            [
+                "https://example.com/a",
+                "https://example.com/a",
+                "https://example.com/b",
+            ]
+        )
+    )
+
+    assert len(result) == 2
+    assert calls["count"] == 2

--- a/tests/test_citation_health.py
+++ b/tests/test_citation_health.py
@@ -1,0 +1,40 @@
+import asyncio
+
+from ai_source_citation.citation_health import CitationHealthChecker
+
+
+def test_health_checker_status_classification() -> None:
+    checker = CitationHealthChecker(
+        fetcher=lambda _url, _timeout: (200, "https://example.com/final")
+    )
+    result = asyncio.run(checker.check("https://example.com"))
+
+    assert result.is_ok is True
+    assert result.is_redirect is False
+    assert result.is_blocked is False
+    assert result.status_code == 200
+    assert result.final_url == "https://example.com/final"
+
+
+def test_health_checker_blocked_status() -> None:
+    checker = CitationHealthChecker(fetcher=lambda _url, _timeout: (403, "https://example.com"))
+    result = asyncio.run(checker.check("https://example.com"))
+
+    assert result.is_ok is False
+    assert result.is_blocked is True
+    assert result.error == "403 Forbidden"
+
+
+def test_health_checker_cache_reuses_result() -> None:
+    calls = {"count": 0}
+
+    def fetcher(_url: str, _timeout: float) -> tuple[int | None, str | None]:
+        calls["count"] += 1
+        return 200, "https://example.com"
+
+    checker = CitationHealthChecker(fetcher=fetcher)
+    result1 = asyncio.run(checker.check("https://example.com"))
+    result2 = asyncio.run(checker.check("https://example.com"))
+
+    assert calls["count"] == 1
+    assert result1 == result2


### PR DESCRIPTION
## Summary
Implements citation URL health validation across the pipeline.

### What this PR adds
- New shared async validator service: `CitationHealthChecker`
  - Follows redirects (urllib default behavior), captures final URL
  - Classifies status into ok/redirect/blocked/fail
  - Handles timeout/network errors gracefully
  - In-memory per-run cache to avoid duplicate checks
  - Concurrency control via semaphore
- Citation model enrichment
  - `Citation.health` now stores `CitationHealthResult`
- Pipeline integration
  - Flow is now: extract citations -> validate citation URLs -> compare expected
- Reporting updates
  - JSON includes per-citation health metadata
  - CSV includes health counters and per-citation status summary
  - HTML report shows citation URL health status and expanded run-level citation health summary metrics
- Tests
  - New `tests/test_citation_health.py` for classification + cache behavior
  - Existing test suite still passes

## Validation
- `poetry run ruff check .`
- `poetry run mypy src`
- `poetry run pytest`

All passing.

Closes #9.
